### PR TITLE
Update Forms and DexTool versions

### DIFF
--- a/TaskrForms/TaskrForms.Android/TaskrForms.Android.csproj
+++ b/TaskrForms/TaskrForms.Android/TaskrForms.Android.csproj
@@ -38,7 +38,7 @@
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <BundleAssemblies>false</BundleAssemblies>
     <MandroidI18n />
-    <AndroidDexTool>dx</AndroidDexTool>
+    <AndroidDexTool>d8</AndroidDexTool>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -87,7 +87,7 @@
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
       <Version>28.0.0.3</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.725" />
+    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991221" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Authentication\Authenticator.cs" />

--- a/TaskrForms/TaskrForms/TaskrForms.csproj
+++ b/TaskrForms/TaskrForms/TaskrForms.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client" Version="4.27.0" />
     <PackageReference Include="sqlite-net-pcl" Version="1.5.231" />
-    <PackageReference Include="Xamarin.Forms" Version="4.5.0.725" />  
+    <PackageReference Include="Xamarin.Forms" Version="4.3.0.991221" />  
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update Forms and DexTool versions

Both of these components cause compatibility issues during build or deployment and need to be changed.

Xamarin.Forms -> 4.3.0.991221
AndroidDexTool -> d8